### PR TITLE
Add serial number to the dimensions footnote

### DIFF
--- a/ridgeback_usermanual.tex
+++ b/ridgeback_usermanual.tex
@@ -231,7 +231,7 @@ Key specifications of Ridgeback are shown in \autoref{systemspecs}.
 \label{systemspecs}
 \end{table}
 
-$^\dagger$ In December 2021 the height of the Ridgeback was increased by 15mm.  Older Ridgebacks measure 296mm (11.6in) high.
+$^\dagger$ In late 2021/early 2022 the height of the Ridgeback was increased by 15mm. Ridgebacks with serial numbers R100-0109 and lower measure 296mm (11.6in) high.
 
 \egroup
 


### PR DESCRIPTION
Revise the footnote to include the final serial number with the old dimensions